### PR TITLE
MOB-2059 : upgrade min sdk version to 16 (Android 4.1) and target sdk version to 27

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -21,8 +21,8 @@ android {
 
     defaultConfig {
         applicationId "org.exoplatform"
-        minSdkVersion 14
-        targetSdkVersion 23
+        minSdkVersion 16
+        targetSdkVersion 27
         versionCode 1604281805
         versionName "5.0"
     }


### PR DESCRIPTION
PLF 5.0 supports Android starting to 4.1, so this PR updates to sdk min version to match with this requirement (API level 16 = 4.1).
Also the target sdk version has been set to 27 (Android 8.1) since I successfully tested it with this sdk.