### PR TITLE
MOB-2155 : make Authentication for REST API work with HTTPS

### DIFF
--- a/app/src/main/java/org/exoplatform/tool/WebViewCookieHandler.java
+++ b/app/src/main/java/org/exoplatform/tool/WebViewCookieHandler.java
@@ -52,7 +52,7 @@ public class WebViewCookieHandler implements CookieJar {
   public List<Cookie> loadForRequest(HttpUrl url) {
     List<Cookie> cookieList = new ArrayList<>();
     if (url != null) {
-      String cookiesStr = webviewCookieManager.getCookie(url.host());
+      String cookiesStr = webviewCookieManager.getCookie(url.url().toString());
       // last_login_username=root;
       // JSESSIONIDSSO=AF9296C7B383CE3D4032340FB36F85C3;
       // JSESSIONID=A068BB1CCBFE5B24BCF5A0E622C193EB


### PR DESCRIPTION
The cookie for authentication for REST calls (JSESSIONID) is not used when connecting on an HTTPS eXo instance. This is because this cookie is set as Secure and calling CookieManager.getCookie with the domain as an argument returns only the non-secure cookies. This method must be called with the "https://" prefix to get all cookies.
This fix uses the full url to be sure to retrieve all cookies.