### PR TITLE
MOB-2197 : rely on filename extension instead of mimetype for files downloads

### DIFF
--- a/app/src/main/java/org/exoplatform/fragment/PlatformWebViewFragment.java
+++ b/app/src/main/java/org/exoplatform/fragment/PlatformWebViewFragment.java
@@ -211,7 +211,7 @@ public class PlatformWebViewFragment extends Fragment {
           requestPermissions(new String[]{ WRITE_EXTERNAL_STORAGE },
                   WRITE_EXTERNAL_STORAGE_PERMISSION_REQUEST);
         } else {
-          downloadFile(url, userAgent, contentDisposition, mimetype);
+          downloadFile(url, userAgent, contentDisposition);
         }
       }
     });
@@ -243,8 +243,8 @@ public class PlatformWebViewFragment extends Fragment {
     return true;
   }
 
-  private void downloadFile(String url, String userAgent, String contentDisposition, String mimetype) {
-    String filename = URLUtil.guessFileName(url, contentDisposition, mimetype);
+  private void downloadFile(String url, String userAgent, String contentDisposition) {
+    String filename = URLUtil.guessFileName(url, contentDisposition, null);
 
     DownloadManager.Request request = new DownloadManager.Request(Uri.parse(url));
 
@@ -266,7 +266,7 @@ public class PlatformWebViewFragment extends Fragment {
       case WRITE_EXTERNAL_STORAGE_PERMISSION_REQUEST: {
         if (grantResults.length > 0
                 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
-          downloadFile(downloadFileUrl, downloadUserAgent, downloadFileContentDisposition, downloadFileMimetype);
+          downloadFile(downloadFileUrl, downloadUserAgent, downloadFileContentDisposition);
         }
         return;
       }


### PR DESCRIPTION
When a file is downloaded, the name used to save the file on the device is calculated from the contentDisposition and the mimetype passed in the URL.
When a file is downoaded from an activity or from the preview, the download URL does not contain the filename (for example /portal/download?resourceId=903576950), the contentDisposition contains the real filename (for example "attachment;filename="my-file.pdf") and the mimetype is set to "application/zip" (for some reasons...).
The method used to calculate the filename is android.webkit.URLUtil#guessFileName.
If the mimeType and the contentDisposition are different, this method replaces the extension of the file by the extension of the mimetype (so in our example it would replace ".pdf" by ".zip").
That's why it stores a zip file instead of the original file type.
This issue does not occurs when the download URL ends with the filename, like in the Documents application (for example "rest/contents/download/collaboration/Users/r___/ro___/roo___/root/Public/Activity+Stream+Documents/my-file.pdf").

This fix set the mimeType to null when calculating the filename in order to ignore it and always rely on the URL or the contentDisposition.