### PR TITLE
MOB-2197 : override file download process to allow downloading files from activites (#18)

### DIFF
--- a/app/src/main/java/org/exoplatform/fragment/PlatformWebViewFragment.java
+++ b/app/src/main/java/org/exoplatform/fragment/PlatformWebViewFragment.java
@@ -211,7 +211,7 @@ public class PlatformWebViewFragment extends Fragment {
           requestPermissions(new String[]{ WRITE_EXTERNAL_STORAGE },
                   WRITE_EXTERNAL_STORAGE_PERMISSION_REQUEST);
         } else {
-          downloadFile(url, userAgent, contentDisposition, mimetype);
+          downloadFile(url, userAgent, contentDisposition);
         }
       }
     });
@@ -243,8 +243,8 @@ public class PlatformWebViewFragment extends Fragment {
     return true;
   }
 
-  private void downloadFile(String url, String userAgent, String contentDisposition, String mimetype) {
-    String filename = URLUtil.guessFileName(url, contentDisposition, mimetype);
+  private void downloadFile(String url, String userAgent, String contentDisposition) {
+    String filename = URLUtil.guessFileName(url, contentDisposition, null);
 
     DownloadManager.Request request = new DownloadManager.Request(Uri.parse(url));
 
@@ -266,7 +266,7 @@ public class PlatformWebViewFragment extends Fragment {
       case WRITE_EXTERNAL_STORAGE_PERMISSION_REQUEST: {
         if (grantResults.length > 0
                 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
-          downloadFile(downloadFileUrl, downloadUserAgent, downloadFileContentDisposition, downloadFileMimetype);
+          downloadFile(downloadFileUrl, downloadUserAgent, downloadFileContentDisposition);
         }
         return;
       }


### PR DESCRIPTION
When fetching an URL, Android checks the headers received and if it contains the relevant one telling that it is a file to download (for example "Content-Disposition: Attachment; filename=example.pdf"), it kills the download (that's why we have Broken pipe exceptions), calls some listeners (onDownloadStart) to allow applications to customize download behavior, then launches again the download. The URL used in eXo to download a file from an activity is /portal/download?resourceId=123456. This uses the DownloadHandler and the DownloadService. The issue comes from the fact that the DownloadService.getDownloadResource method removes the resource once it is called, and since the URL is called twice by Android, the first request returns correctly the document (but it is not used by Android since the download is killed) but not the second one (that's why we have a message explaining that the resource does not exist).
One solution could be to not use the DownloadService but instead the /rest/content endpoint. It would work for single files, but not for multiple files which are zipped before being sent.

So the choosen solution is to allow to download a file with DownloadService without removing it (see gatein-portal) and use this capability for the first request. Then the file will still be available for the second request. So the first request uses the parameter remove=false to download the file without removing it, and stores the resourceId in a map to know the first request as been done. For the second request, since the resourceId is in the map, we know we don't need to add the remove=false paramater.