### PR TITLE
MOB-2303 : Fix Share files from Android

### DIFF
--- a/app/src/main/java/org/exoplatform/service/share/LoginTask.java
+++ b/app/src/main/java/org/exoplatform/service/share/LoginTask.java
@@ -117,7 +117,7 @@ public class LoginTask extends AsyncTask<Server, Void, LoginTask.LoginResult> {
       Double plfVersion = ServerUtils.convertVersionFromString(result.mPlatformInfo.platformVersion);
       if (plfVersion >= App.Platform.MIN_SUPPORTED_VERSION) {
         // Login successful and Platform version supported
-        PlatformUtils.init(result.mServer.getUrl().toString(), result.mPlatformInfo);
+        PlatformUtils.init(result.mServer.getUrl().toString(), result.mPlatformInfo, result.mServer.getLastLogin());
         for (Listener l : mListeners) {
           l.onLoginSuccess(result.mPlatformInfo);
         }

--- a/app/src/main/java/org/exoplatform/service/share/PostAction.java
+++ b/app/src/main/java/org/exoplatform/service/share/PostAction.java
@@ -101,16 +101,16 @@ public class PostAction extends Action {
     SocialRestService service = retrofit.create(SocialRestService.class);
     try {
       if (postInfo.isPublic()) {
-        Response<SocialActivity> response = service.createActivity("", postInfo).execute();
+        Response<SocialActivity> response = service.createPublicActivity(postInfo.ownerAccount.getLastLogin(), postInfo).execute();
         if (listener instanceof PostActionListener && response.isSuccessful()) {
           ((PostActionListener) listener).mCreatedActivity = response.body();
         }
         return response.isSuccessful(); // return the result of the createActivity
                                         // method call
       } else {
-        String spaceId = postInfo.destinationSpace.getIdentityId();
+        String spaceId = postInfo.destinationSpace.id;
         if (spaceId != null) {
-          Response<SocialActivity> response = service.createActivity(spaceId, postInfo).execute();
+          Response<SocialActivity> response = service.createSpaceActivity(spaceId, postInfo).execute();
           if (listener instanceof PostActionListener && response.isSuccessful()) {
             ((PostActionListener) listener).mCreatedActivity = response.body();
           }

--- a/app/src/main/java/org/exoplatform/tool/PlatformUtils.java
+++ b/app/src/main/java/org/exoplatform/tool/PlatformUtils.java
@@ -37,11 +37,20 @@ public class PlatformUtils {
 
   private static String       platformDomain;
 
-  public static void init(String domain, PlatformInfo info) {
+  public static void init(String domain, PlatformInfo info, String userName) {
     if (domain == null || info == null)
       throw new IllegalArgumentException("Domain and Info parameters must not be null.");
 
     platformInfo = info;
+    if(platformInfo.defaultWorkSpaceName == null || platformInfo.defaultWorkSpaceName.isEmpty()) {
+      platformInfo.defaultWorkSpaceName = "collaboration";
+    }
+    if(platformInfo.currentRepoName == null || platformInfo.currentRepoName.isEmpty()){
+      platformInfo.currentRepoName = "repository";
+    }
+    if(platformInfo.userHomeNodePath == null || platformInfo.userHomeNodePath.isEmpty()) {
+      platformInfo.userHomeNodePath = makeUserPersonalDocumentsPath(userName);
+    }
 
     try {
       URL urlDomain = new URL(domain);
@@ -59,6 +68,7 @@ public class PlatformUtils {
   public static String getUserHomeJcrFolderPath() {
     if (platformInfo == null || platformDomain == null)
       throw new NullPointerException("Incorrect Platform domain or info attributes. Use PlatformUtils.init().");
+
 
     StringBuilder b = new StringBuilder(platformDomain).append(App.Platform.DOCUMENT_JCR_PATH)
                                                        .append("/")
@@ -78,4 +88,9 @@ public class PlatformUtils {
   public static String getPlatformDomain() {
     return platformDomain;
   }
+
+  private static String makeUserPersonalDocumentsPath(String userName) {
+    return "/Users/" + userName.substring(0,1) + "___/" +  userName.substring(0,2) + "___/" + userName;
+  }
+
 }

--- a/app/src/main/java/org/exoplatform/tool/ServerUtils.java
+++ b/app/src/main/java/org/exoplatform/tool/ServerUtils.java
@@ -65,7 +65,7 @@ public class ServerUtils {
     public static String plfVersion;
 
     public static boolean isOldVersion() {
-        if (plfVersion.substring(0, 5).compareTo("5.2.2") <= 0)
+        if (plfVersion != null && plfVersion.substring(0, 5).compareTo("5.2.2") <= 0)
             return true;
         else return false;
     }


### PR DESCRIPTION
It is not possible to share files from mobile to eXo platform server because of many issues : 
* Use of a deprecated Rest API for creating activities
* Missing some parameters (workspace/repository/personal folder) for eXo platform 6.0.x
* Problem getting platform version
The PR will fix all above by : 
* Switching to the new Rest API for creating activities
* Add default values for missing parameters
* Check nullity of each parameter