### PR TITLE
MOB-2262 : Fix Like/Comment actions when opening activity from Push notification

### DIFF
--- a/app/src/main/java/org/exoplatform/fragment/PlatformWebViewFragment.java
+++ b/app/src/main/java/org/exoplatform/fragment/PlatformWebViewFragment.java
@@ -465,12 +465,7 @@ public class PlatformWebViewFragment extends Fragment {
       super.onPageStarted(view, url, favicon);
       Uri uri = Uri.parse(url);
       // Show / hide the Done button
-      String contentType = URLConnection.guessContentTypeFromName(uri.getPath());
-      if (contentType == null)
-        getContentTypeAsync(url);
-      // new GetContentTypeHeaderTask().execute(url);
-      else
-        refreshLayoutForContent(contentType);
+      refreshLayoutForContent("text/html");
       // Inform the activity whether we are on the login or register page
       String path = uri.getPath();
       if (mListener != null)


### PR DESCRIPTION
When opening an activity from Push notification, Like/Comment buttons are not considered and does refresh the page.
The root cause of the problem is that Mobile application renders twice each page. The first call renders the page and the second do a HEAD call to check the content-type which is no more needed for eXo platform as we have almost all file viewers embedded. 
First call initiates all Webui components and adds them to the page, the second one recreates those components without updating the DOM causing the depreciation of the IDs all Webui components . This makes all actions (Like/Comment/ etc ...) to fail and just refresh the page.
In the fix I put the content type to text/html by default, without removing the whole logic, to avoid making the HTTP request with HEAD method.