### PR TITLE
MOB-2303 : Enable using deprecated HTTP client for Android 9

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -40,6 +40,9 @@
         android:label="eXo${appLabelEnvironmentSuffix}"
         android:theme="@style/MainTheme">
 
+        <!-- Enable Apache HTTP for Android 9 -->
+        <uses-library android:name="org.apache.http.legacy" android:required="false"/>
+
         <!-- Activities -->
         <!-- Home activity -->
         <activity android:name=".activity.ConnectServerActivity">

--- a/app/src/main/java/org/exoplatform/App.java
+++ b/app/src/main/java/org/exoplatform/App.java
@@ -77,6 +77,8 @@ public class App extends Application {
 
     public static final String DOCUMENT_CONTROL_PATH_REST   = "/rest/managedocument/uploadFile/control";
 
+    public static final String CREATE_FOLDER_PATH_REST   = "/rest/private/managedocument/createFolder";
+
     public static final Double MIN_SUPPORTED_VERSION        = 4.3;
   }
 

--- a/app/src/main/java/org/exoplatform/model/UploadInfo.java
+++ b/app/src/main/java/org/exoplatform/model/UploadInfo.java
@@ -68,13 +68,13 @@ public class UploadInfo {
       // File will be uploaded in the Public folder of the user's drive
       // e.g. /Users/u___/us___/use___/user/Public/Mobile
       drive = App.Platform.DOCUMENT_PERSONAL_DRIVE_NAME;
-      folder = "Public/Mobile";
+      folder = "Public/mobile";
       jcrUrl = PlatformUtils.getUserHomeJcrFolderPath();
     } else {
       // File will be uploaded in the Documents folder of the space's drive
       // e.g. /Groups/spaces/the_space/Documents/Mobile
       drive = ".spaces." + postInfo.destinationSpace.getOriginalName();
-      folder = "Mobile";
+      folder = "mobile";
       StringBuilder url = new StringBuilder(postInfo.ownerAccount.getUrl().toString()).append(App.Platform.DOCUMENT_JCR_PATH)
                                                                                       .append("/")
                                                                                       .append(repository)

--- a/app/src/main/java/org/exoplatform/service/share/CreateFolderAction.java
+++ b/app/src/main/java/org/exoplatform/service/share/CreateFolderAction.java
@@ -54,9 +54,7 @@ public class CreateFolderAction extends Action {
 
   @Override
   protected boolean doExecute() {
-
-    String folderUrl = uploadInfo.jcrUrl + "/" + uploadInfo.folder;
-    boolean createFolder = DocumentUtils.createFolder(folderUrl);
+    boolean createFolder = DocumentUtils.createFolder(uploadInfo);
     boolean ret;
     if (createFolder) {
       ret = listener.onSuccess("Destination folder ready");

--- a/app/src/main/java/org/exoplatform/service/share/ShareService.java
+++ b/app/src/main/java/org/exoplatform/service/share/ShareService.java
@@ -21,10 +21,12 @@ package org.exoplatform.service.share;
  */
 
 import android.app.IntentService;
+import android.app.NotificationChannel;
 import android.app.NotificationManager;
 import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
+import android.os.Build;
 import android.support.annotation.NonNull;
 import android.support.v4.app.NotificationCompat;
 import android.util.Log;
@@ -78,6 +80,10 @@ public class ShareService extends IntentService {
   private int                notifId     = 1;
 
   private SocialActivity     postInfo;
+
+  private static String CHANNEL_NAME = "EXO_CHANNEL";
+  private static String CHANNEL_DESCRIPTION = "EXO_CHANNEL_DESCRIPTION";
+  private static String CHANNEL_ID = "EXO_CHANNEL_ID";
 
   // key is uri in device, value is url on server
   private List<UploadInfo>   uploadedMap = new ArrayList<>();
@@ -372,7 +378,7 @@ public class ShareService extends IntentService {
                                            : getString(R.string.ShareService_Title_ShareMessage);
     String text = postInfo.hasAttachment() ? getString(R.string.ShareService_Message_UploadInProgress)
                                           : getString(R.string.ShareService_Message_PostShortly);
-    NotificationCompat.Builder builder = new NotificationCompat.Builder(getApplicationContext());
+    NotificationCompat.Builder builder = new NotificationCompat.Builder(getApplicationContext(), "EXO_NOTIFICATION_CHANNEL");
     builder.setSmallIcon(R.drawable.icon_share_notif);
     builder.setContentTitle(title);
     builder.setContentText(text);
@@ -439,7 +445,8 @@ public class ShareService extends IntentService {
     }
     String title = postInfo.hasAttachment() ? getString(R.string.ShareService_Title_ShareDocument)
                                            : getString(R.string.ShareService_Title_ShareMessage);
-    NotificationCompat.Builder builder = new NotificationCompat.Builder(getApplicationContext());
+    createNotificationChannel();
+    NotificationCompat.Builder builder = new NotificationCompat.Builder(getApplicationContext(), CHANNEL_ID);
     builder.setSmallIcon(R.drawable.icon_share_notif);
     builder.setContentTitle(title);
     builder.setContentText(text);
@@ -447,6 +454,22 @@ public class ShareService extends IntentService {
     builder.setProgress(0, 0, false);
     NotificationManager manager = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
     manager.notify(notifId, builder.build());
+  }
+
+  /**
+   * Creates a Notification channel
+   */
+  private void createNotificationChannel() {
+
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+      int importance = NotificationManager.IMPORTANCE_DEFAULT;
+      NotificationChannel channel = new NotificationChannel(CHANNEL_ID, CHANNEL_NAME, importance);
+      channel.setDescription(CHANNEL_DESCRIPTION);
+      // Register the channel with the system; you can't change the importance
+      // or other notification behaviors after this
+      NotificationManager notificationManager = getSystemService(NotificationManager.class);
+      notificationManager.createNotificationChannel(channel);
+    }
   }
 
 }

--- a/app/src/main/java/org/exoplatform/tool/DocumentUtils.java
+++ b/app/src/main/java/org/exoplatform/tool/DocumentUtils.java
@@ -172,7 +172,7 @@ public class DocumentUtils {
        */
       String decodedUri = Uri.decode(document.toString());
       int fileIdx = decodedUri.indexOf("file://");
-      if (fileIdx > -1) {
+      if (fileIdx > -1 && !decodedUri.startsWith("content://com.google.android.apps")) {
         long id = -1;
         try {
           id = ContentUris.parseId(document);

--- a/app/src/main/java/org/exoplatform/tool/PlatformUtils.java
+++ b/app/src/main/java/org/exoplatform/tool/PlatformUtils.java
@@ -90,7 +90,13 @@ public class PlatformUtils {
   }
 
   private static String makeUserPersonalDocumentsPath(String userName) {
-    return "/Users/" + userName.substring(0,1) + "___/" +  userName.substring(0,2) + "___/" + userName;
+    String userPath = "";
+    if(userName.length() <= 3) {
+      userPath = "/Users/" + userName.substring(0, 1) + "___/" + userName.substring(0, 2) + "___/" + userName;
+    } else {
+      userPath = "/Users/" + userName.substring(0, 1) + "___/" + userName.substring(0, 2) + "___/" + userName.substring(0, 3) + "___/" + userName;
+    }
+    return userPath;
   }
 
 }


### PR DESCRIPTION
With Android 9, Apache HTTP was deprecated which prevents using this library from communication between the app and eXo server. A workaround was proposed in Android documentation https://developer.android.com/about/versions/pie/android-9.0-changes-28#apache-p to fix it. 