### PR TITLE
MOB-2303 : Enable using deprecated HTTP client for Android 9

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -40,6 +40,9 @@
         android:label="eXo${appLabelEnvironmentSuffix}"
         android:theme="@style/MainTheme">
 
+        <!-- Enable Apache HTTP for Android 9 -->
+        <uses-library android:name="org.apache.http.legacy" android:required="false"/>
+
         <!-- Activities -->
         <!-- Home activity -->
         <activity android:name=".activity.ConnectServerActivity">


### PR DESCRIPTION
With Android 9, Apache HTTP was deprecated which prevents using this library from communication between the app and eXo server. A workaround was proposed in Android documentation https://developer.android.com/about/versions/pie/android-9.0-changes-28#apache-p to fix it.