### PR TITLE
TASK-51600: Update minSdkVersion and compileSdkVersion to 30 (Android11)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,6 @@ task clean(type: Delete) {
 
 // This block encapsulate custom properties and make them available to all modules in the project.
 ext {
-    minSdkVersion = 28 // Android 9.0 Pie
-    compileSdkVersion = 28
+    minSdkVersion = 30 // Android 11.0 Android11
+    compileSdkVersion = 30
 }


### PR DESCRIPTION
Google requires minimum SDK version [30](https://developer.android.com/distribute/best-practices/develop/target-sdk.html) (Android11) 