### PR TITLE
52242 : URL input field should be empty

### DIFF
--- a/app/src/main/java/org/exoplatform/activity/AddDomainServerActivity.java
+++ b/app/src/main/java/org/exoplatform/activity/AddDomainServerActivity.java
@@ -32,7 +32,7 @@ import org.exoplatform.tool.ServerUtils;
 public class AddDomainServerActivity extends AppCompatActivity {
     ImageView closeButton;
     Button  clearButton;
-    EditText companyTextField,addDomainTextField;
+    EditText companyTextField;
     RelativeLayout parentLayout,addDomainButton;
     LinearLayout topViewAddUrlLayout;
     Boolean isAlreadyFocused = false;
@@ -51,7 +51,6 @@ public class AddDomainServerActivity extends AppCompatActivity {
         checkConnectivity = new CheckConnectivity(AddDomainServerActivity.this);
         parentLayout = findViewById(R.id.container_add_view);
         topViewAddUrlLayout = (LinearLayout) findViewById(R.id.topViewAddUrl);
-        addDomainTextField = (EditText) findViewById(R.id.textEditAddDomain);
         companyTextField = (EditText) findViewById(R.id.company_placeholder);
         closeButton = (ImageView) findViewById(R.id.close_button_add_domain);
         clearButton = (Button) findViewById(R.id.clear_button_add_domain);
@@ -60,6 +59,7 @@ public class AddDomainServerActivity extends AppCompatActivity {
         addURLTextView = (TextView) findViewById(R.id.addURLTextView);
         headerTitle.setText(R.string.AddDomain_Title_Header);
         addURLTextView.setText(R.string.AddDomain_Title_addURL);
+        companyTextField.setHint(R.string.AddDomain_Title_Placeholder);
         statusBarColor();
         handleActionGoKeyKeyboard();
         addDomainButton.setOnClickListener(new View.OnClickListener() {
@@ -73,13 +73,10 @@ public class AddDomainServerActivity extends AppCompatActivity {
             @Override
             public void onClick(View v) {
                 companyTextField.getText().clear();
-                addDomainTextField.getText().clear();
-                companyTextField.setVisibility(View.GONE);
-                requestFocusTo(addDomainTextField);
+                requestFocusTo(companyTextField);
             }
         });
         companyTextField.requestFocus();
-        addDomainTextField = (EditText) findViewById(R.id.textEditAddDomain);
         companyTextField.setOnTouchListener((arg0, arg1) -> {
             if (!isAlreadyFocused) {
                 companyTextField.setHint("");
@@ -108,7 +105,7 @@ public class AddDomainServerActivity extends AppCompatActivity {
     // when users taps "Go" or "Enter" on the keyboard
     private void submitUrl() {
         if (checkConnectivity.isConnectedToInternet()) {
-            String urlPrefix = companyTextField.getText().toString() + addDomainTextField.getText().toString();
+            String urlPrefix = companyTextField.getText().toString();
             if (!urlPrefix.startsWith("https://")) {
                 urlPrefix = "https://" + urlPrefix;
             }
@@ -178,16 +175,6 @@ public class AddDomainServerActivity extends AppCompatActivity {
     }
 
     private void handleActionGoKeyKeyboard(){
-        addDomainTextField.setOnEditorActionListener(new TextView.OnEditorActionListener() {
-            @Override
-            public boolean onEditorAction(TextView v, int actionId, KeyEvent event) {
-                if (actionId == EditorInfo.IME_ACTION_GO) {
-                    submitUrl();
-                    return true;
-                }
-                return false; // otherwise let the system handle the event
-            }
-        });
         companyTextField.setOnEditorActionListener(new TextView.OnEditorActionListener() {
             @Override
             public boolean onEditorAction(TextView v, int actionId, KeyEvent event) {

--- a/app/src/main/res/layout/activity_add_domain_server.xml
+++ b/app/src/main/res/layout/activity_add_domain_server.xml
@@ -108,34 +108,21 @@
 
                     <EditText
                         android:id="@+id/company_placeholder"
-                        android:layout_width="wrap_content"
+                        android:layout_width="270dp"
                         android:layout_height="match_parent"
-                        android:paddingStart="20sp"
-                        android:hint="company"
-                        android:maxLines="1"
-                        android:cursorVisible="true"
-                        android:textAllCaps="false"
-                        android:textColor="@color/cardview_dark_background"
-                        android:textColorHint="@color/eXoGreyTransparent"
-                        android:textSize="15sp"
-                        android:inputType="text|textNoSuggestions"
-                        android:singleLine="true"
                         android:background="@android:color/transparent"
-                        android:imeOptions="actionGo" />
-
-                    <EditText
-                        android:id="@+id/textEditAddDomain"
-                        android:layout_width="186dp"
-                        android:layout_height="match_parent"
-                        android:layout_marginRight="0dp"
+                        android:cursorVisible="true"
+                        android:hint="Please enter your url"
                         android:imeOptions="actionGo"
                         android:inputType="text|textNoSuggestions"
                         android:maxLines="1"
+                        android:paddingStart="20sp"
                         android:singleLine="true"
-                        android:text=".exoplatform.org"
                         android:textAllCaps="false"
-                        android:background="@android:color/transparent"                        android:textColor="@color/cardview_dark_background"
+                        android:textColor="@color/cardview_dark_background"
+                        android:textColorHint="@color/eXoGreyTransparent"
                         android:textSize="15sp" />
+
                 </LinearLayout>
 
                 <RelativeLayout

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -88,6 +88,7 @@
     <!-- Add Domain -->
     <string name="AddDomain.Title.Header">Add your eXo</string>
     <string name="AddDomain.Title.addURL">Enter your eXo URL</string>
+    <string name="AddDomain.Title.Placeholder">Please enter your url</string>
 
     <!-- Share Extension -->
     <string name="ShareActivity.Main.Title.Post">Post</string>


### PR DESCRIPTION
Actual behavior:

Using eXo mobile apps, URL "company.exoplatform.org" pre-registered in the input field

Suggested:
as it confuses users, URL input field should be empty with a placeholder : Please enter your url

reported in : https://community.exoplatform.com/portal/dw/forum/topic/topic6c05ab82ac19000f6208ba1e0ccf35f3