### PR TITLE
53288 : Jitsi Call ringtone on android device

### DIFF
--- a/app/src/main/java/org/exoplatform/fragment/PlatformWebViewFragment.java
+++ b/app/src/main/java/org/exoplatform/fragment/PlatformWebViewFragment.java
@@ -189,6 +189,7 @@ public class PlatformWebViewFragment extends Fragment {
     mWebView.getSettings().setMixedContentMode(WebSettings.MIXED_CONTENT_ALWAYS_ALLOW);
     mWebView.getSettings().setLayoutAlgorithm(WebSettings.LayoutAlgorithm.NORMAL);
     mWebView.getSettings().setDisplayZoomControls(false);
+    mWebView.getSettings().setMediaPlaybackRequiresUserGesture(false);
 
     // set progress bar
     mProgressBar = (ProgressBar) layout.findViewById(R.id.PlatformWebViewFragment_ProgressBar);


### PR DESCRIPTION
When we receive a call on jitsi when we use an android mobile, we need to get a ringtone, the same we have on desktop web. 