### PR TITLE
51879 : Deep link to open application from external app

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -29,6 +29,14 @@
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="https"
+                    android:host="community.exoplatform.com"
+                    android:pathPrefix="/portal" />
+            </intent-filter>
         </activity>
         <activity
             android:name=".activity.ConnectToExoListActivity"

--- a/app/src/main/java/org/exoplatform/activity/LauncherActivity.java
+++ b/app/src/main/java/org/exoplatform/activity/LauncherActivity.java
@@ -6,6 +6,7 @@ import androidx.appcompat.app.AppCompatActivity;
 
 import android.content.Intent;
 import android.content.SharedPreferences;
+import android.net.Uri;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
 import android.util.Log;
@@ -45,6 +46,8 @@ public class LauncherActivity extends AppCompatActivity {
         SharedPreferences shared = PreferenceManager.getDefaultSharedPreferences(LauncherActivity.this);
         Server serverToConnect = new ServerManagerImpl(prefs).getLastVisitedServer();
         SharedPreferences.Editor editor = shared.edit();
+        Uri uri = getIntent().getData();
+
         try {
             setWakeUpActivityRoot(new LauncherActivity.ResultHandler<Boolean>() {
                 @Override
@@ -54,10 +57,15 @@ public class LauncherActivity extends AppCompatActivity {
                         if(url != null && !url.equals("")) {
                             openWebViewWithURL(url);
                         } else {
-                            String urlLogin = shared.getString("urlLogin", serverToConnect.getUrl().toString());
-                            openWebViewWithURL(urlLogin);
-                            editor.putBoolean("isSessionTimedOut",false);
-                            editor.apply();
+                            if (uri != null) {
+                                Log.d("deepLink url ======>",uri.toString());
+                                openWebViewWithURL(uri.toString());
+                            }else {
+                                String urlLogin = shared.getString("urlLogin", serverToConnect.getUrl().toString());
+                                openWebViewWithURL(urlLogin);
+                                editor.putBoolean("isSessionTimedOut",false);
+                                editor.apply();
+                            }
                         }
                     }else{
                         Intent intent = new Intent(LauncherActivity.this, ConnectToExoListActivity.class);


### PR DESCRIPTION
I want to be able to open eXo Android mobile app when i click on a community link in external app (like email, other apps) and it will opens eXo Android mobile application.

Case of a user that does have the app installed on his device:

When he connects for the first time or does not have an account, the onboarding page is displayed.
when he does have an account, disconnected from an instance, he will get instances view
when he had w timeout session, the instances page is displayed 
When he is already connected, the clicked link will be opened in the app related to the link.
Case of a user that does not have the app installed on his device:

The link will be opened in a the default mobile browser and a popup is displayed suggesting to download eXo app.