### PR TITLE
53341 : blank page is displayed after ending a jitsi call

### DIFF
--- a/app/src/main/java/org/exoplatform/fragment/PlatformWebViewFragment.java
+++ b/app/src/main/java/org/exoplatform/fragment/PlatformWebViewFragment.java
@@ -464,7 +464,7 @@ public class PlatformWebViewFragment extends Fragment {
       if (url.contains(LOGOUT_PATH)) {
         mListener.onUserJustBeforeSignedOut();
       }
-      if (url.contains(mServer.getShortUrl()) && !super.shouldOverrideUrlLoading(view, request) && !url.contains(mServer.getShortUrl() + "/jitsi/"))  {
+      if (url.contains(mServer.getShortUrl()) && !super.shouldOverrideUrlLoading(view, request))  {
         // url is on the server's domain, keep loading normally
         return false;
       } else {

--- a/app/src/main/java/org/exoplatform/fragment/WebViewFragment.java
+++ b/app/src/main/java/org/exoplatform/fragment/WebViewFragment.java
@@ -103,17 +103,13 @@ public class WebViewFragment extends Fragment {
     mWebView.getSettings().setDisplayZoomControls(false);
     mProgressBar = (ProgressBar) layout.findViewById(R.id.WebViewFragment_ProgressBar);
 
-    String[] permissions =
-            {Manifest.permission.READ_EXTERNAL_STORAGE,
-                    Manifest.permission.WRITE_EXTERNAL_STORAGE,
-                    Manifest.permission.INTERNET,
-                    Manifest.permission.RECORD_AUDIO,
-                    Manifest.permission.CAMERA};
+    String[] permissions = { Manifest.permission.READ_EXTERNAL_STORAGE,
+                             Manifest.permission.WRITE_EXTERNAL_STORAGE,
+                             Manifest.permission.INTERNET,
+                             Manifest.permission.RECORD_AUDIO,
+                             Manifest.permission.CAMERA };
 
-    ActivityCompat.requestPermissions(
-            this.getActivity(),
-            permissions,
-            1010);
+    ActivityCompat.requestPermissions(this.getActivity(),permissions,1010);
     mWebView.setWebChromeClient(new WebChromeClient() {
       @Override
       public void onReceivedTitle(WebView view, String title) {


### PR DESCRIPTION
Environnement : Android

user A launches a call to user B,
user B accept the call and the 2 users are in the meet 
user B end the call 
Current behavior : 

 blank page is displayed after ending a jitsi call

Expected behavior : 

the call must be finished for both participants, and the users will be redirected to the last page he was connected to just before accepting the call

https://youtu.be/J5FOc0MTB1g