### PR TITLE
54635 : [Gsuite]the connection parameters are always saved even after…

### DIFF
--- a/app/.idea/.gitignore
+++ b/app/.idea/.gitignore
@@ -1,0 +1,3 @@
+# Default ignored files
+/shelf/
+/workspace.xml

--- a/app/.idea/gradle.xml
+++ b/app/.idea/gradle.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="GradleSettings">
+    <option name="linkedExternalProjectsSettings">
+      <GradleProjectSettings>
+        <option name="testRunner" value="GRADLE" />
+        <option name="distributionType" value="DEFAULT_WRAPPED" />
+        <option name="externalProjectPath" value="$PROJECT_DIR$" />
+        <option name="gradleHome" value="/usr/local/Cellar/gradle/7.2/libexec" />
+        <option name="resolveModulePerSourceSet" value="false" />
+      </GradleProjectSettings>
+    </option>
+  </component>
+</project>

--- a/app/.idea/misc.xml
+++ b/app/.idea/misc.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager" version="2" project-jdk-name="11" project-jdk-type="JavaSDK">
+    <output url="file://$PROJECT_DIR$/build/classes" />
+  </component>
+  <component name="ProjectType">
+    <option name="id" value="Android" />
+  </component>
+</project>

--- a/app/.idea/modules.xml
+++ b/app/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/app.iml" filepath="$PROJECT_DIR$/.idea/modules/app.iml" />
+    </modules>
+  </component>
+</project>

--- a/app/.idea/vcs.xml
+++ b/app/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$/.." vcs="Git" />
+  </component>
+</project>


### PR DESCRIPTION
… disconnection & without check on remember me

Env : Beta 04 - Android

Steps to reproduce :

Connect to user account
Type the connection parameters without saving them
Disconnect and launch the site a second time and check 
Disconnect and delete the saved instance from card screen 
Expected behavior : 

for both cases ,user must be invited to re-enter his authentication details so that he can connect

Current behavior : 

the connection parameters are always saved even after disconnection and without check "remember me"
