### PR TITLE
54635 : Gsuite the connection parameters are always saved even after …

### DIFF
--- a/app/.idea/workspace.xml
+++ b/app/.idea/workspace.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AutoImportSettings">
+    <option name="autoReloadType" value="NONE" />
+  </component>
+  <component name="ChangeListManager">
+    <list default="true" id="ddaed6af-fc91-4e46-8e30-4b76de3d93ef" name="Default Changelist" comment="" />
+    <option name="SHOW_DIALOG" value="false" />
+    <option name="HIGHLIGHT_CONFLICTS" value="true" />
+    <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
+    <option name="LAST_RESOLUTION" value="IGNORE" />
+  </component>
+  <component name="Git.Settings">
+    <option name="RECENT_GIT_ROOT_PATH" value="$PROJECT_DIR$/.." />
+  </component>
+  <component name="ProjectId" id="25ViMnsghHEhjaO4KTCn2TKd8KW" />
+  <component name="ProjectLevelVcsManager" settingsEditedManually="true" />
+  <component name="ProjectViewState">
+    <option name="hideEmptyMiddlePackages" value="true" />
+    <option name="showLibraryContents" value="true" />
+  </component>
+  <component name="PropertiesComponent">
+    <property name="RunOnceActivity.OpenProjectViewOnStart" value="true" />
+    <property name="RunOnceActivity.ShowReadmeOnStart" value="true" />
+    <property name="dart.analysis.tool.window.visible" value="false" />
+    <property name="show.migrate.to.gradle.popup" value="false" />
+  </component>
+  <component name="SpellCheckerSettings" RuntimeDictionaries="0" Folders="0" CustomDictionaries="0" DefaultDictionary="application-level" UseSingleDictionary="true" transferred="true" />
+  <component name="TaskManager">
+    <task active="true" id="Default" summary="Default task">
+      <changelist id="ddaed6af-fc91-4e46-8e30-4b76de3d93ef" name="Default Changelist" comment="" />
+      <created>1645618612454</created>
+      <option name="number" value="Default" />
+      <option name="presentableId" value="Default" />
+      <updated>1645618612454</updated>
+    </task>
+    <servers />
+  </component>
+  <component name="Vcs.Log.Tabs.Properties">
+    <option name="TAB_STATES">
+      <map>
+        <entry key="MAIN">
+          <value>
+            <State />
+          </value>
+        </entry>
+      </map>
+    </option>
+  </component>
+</project>

--- a/app/src/main/java/org/exoplatform/fragment/PlatformWebViewFragment.java
+++ b/app/src/main/java/org/exoplatform/fragment/PlatformWebViewFragment.java
@@ -55,6 +55,7 @@ import android.webkit.WebResourceError;
 import android.webkit.WebResourceRequest;
 import android.webkit.WebResourceResponse;
 import android.webkit.WebSettings;
+import android.webkit.WebStorage;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
 import android.widget.Button;
@@ -152,6 +153,15 @@ public class PlatformWebViewFragment extends Fragment {
   private String downloadFileContentDisposition;
 
   private String downloadFileMimetype;
+
+  private boolean isWhileLoginProcess = false;
+
+  private final String               FACEBOOK_LOGIN_PATH = "www.facebook.com/dialog/oauth";
+
+  private final String               GOOGLE_LOGIN_PATH = "accounts.google.com/o/oauth2";
+
+  private final String               LINKEDIN_LOGIN_PATH = "www.linkedin.com/uas/oauth2";
+
   Integer count = 0;
 
   public PlatformWebViewFragment() {
@@ -506,15 +516,25 @@ public class PlatformWebViewFragment extends Fragment {
       Log.d("shouldOverride", url);
       // For external and short links, broadcast logout event if done
       if (url.contains(LOGOUT_PATH)) {
+        clearWebviewData();
         mListener.onUserJustBeforeSignedOut();
       }
-      if (url.contains(mServer.getShortUrl()) && !super.shouldOverrideUrlLoading(view, request))  {
+
+      if (url.contains(GOOGLE_LOGIN_PATH) || url.contains(FACEBOOK_LOGIN_PATH) || url.contains(LINKEDIN_LOGIN_PATH)) {
+         isWhileLoginProcess = true ;
+      }
+
+      if (url.contains(mServer.getShortUrl()) && url.contains("/portal/login?username=")) {
+        isWhileLoginProcess = false ;
+      }
+
+      if (((url.contains(mServer.getShortUrl()) && !super.shouldOverrideUrlLoading(view, request))) || isWhileLoginProcess) {
         // url is on the server's domain, keep loading normally
         return false;
-      } else {
-        // url is on an external domain, load in a different fragment
-        mListener.onExternalContentRequested(url);
-        return true;
+      } else{
+          // url is on an external domain, load in a different fragment
+          mListener.onExternalContentRequested(url);
+          return true;
       }
     }
 
@@ -532,9 +552,11 @@ public class PlatformWebViewFragment extends Fragment {
       // Return to the previous activity if user has signed out
       String queryString = uri.getQuery();
       if (queryString != null && queryString.contains("portal:action=Logout")) {
+        clearWebviewData();
         mListener.onUserSignedOut();
       }
     }
+
 
     @Override
     public void onPageFinished(WebView view, String url) {
@@ -558,18 +580,19 @@ public class PlatformWebViewFragment extends Fragment {
 
   }
 
-  public interface PlatformNavigationCallback {
-    void onPageStarted(boolean needsToolbar);
+  // Clear Webview cache and data before logging out.
 
-    void onUserSignedOut();
-
-    void onUserJustBeforeSignedOut();
-
-    void onExternalContentRequested(String url);
-
-    void onFirstTimeUserLoggedIn();
+  private void clearWebviewData() {
+    mWebView.clearCache(true);
+    mWebView.clearFormData();
+    mWebView.clearHistory();
+    mWebView.clearSslPreferences();
+    PlatformWebViewFragment.this.getContext().deleteDatabase("webviewCache.db");
+    PlatformWebViewFragment.this.getContext().deleteDatabase("webview.db");
+    CookieManager.getInstance().removeAllCookies(null);
+    CookieManager.getInstance().flush();
+    WebStorage.getInstance().deleteAllData();
   }
-
 
   private void getAvatarServerLogo() {
     SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(PlatformWebViewFragment.this.getContext());
@@ -617,5 +640,18 @@ public class PlatformWebViewFragment extends Fragment {
     Log.d("Image Log:", imageEncoded);
     return imageEncoded;
   }
+
+  public interface PlatformNavigationCallback {
+    void onPageStarted(boolean needsToolbar);
+
+    void onUserSignedOut();
+
+    void onUserJustBeforeSignedOut();
+
+    void onExternalContentRequested(String url);
+
+    void onFirstTimeUserLoggedIn();
+  }
+
 }
 


### PR DESCRIPTION
…disconnection & without check on remember me

Env : Beta 04 - Android

Steps to reproduce :

Connect to user account
Type the connection parameters without saving them
Disconnect and launch the site a second time and check 
Disconnect and delete the saved instance from card screen 
Expected behavior : 

for both cases ,user must be invited to re-enter his authentication details so that he can connect

Current behavior : 

the connection parameters are always saved even after disconnection and without check "remember me"

https://youtu.be/Bj8xfjkZbjs