### PR TITLE
54806 : Wrong redirection when i access to exo app

### DIFF
--- a/app/src/main/java/org/exoplatform/activity/LauncherActivity.java
+++ b/app/src/main/java/org/exoplatform/activity/LauncherActivity.java
@@ -61,9 +61,9 @@ public class LauncherActivity extends AppCompatActivity {
                                 Log.d("deepLink url ======>",uri.toString());
                                 openWebViewWithURL(uri.toString());
                             }else {
-                                String urlLogin = shared.getString("urlLogin", serverToConnect.getUrl().toString());
-                                openWebViewWithURL(urlLogin);
-                                editor.putBoolean("isSessionTimedOut",false);
+                                Intent intent = new Intent(LauncherActivity.this, ConnectToExoListActivity.class);
+                                startActivity(intent);
+                                editor.putBoolean("isSessionTimedOut",true);
                                 editor.apply();
                             }
                         }


### PR DESCRIPTION
Steps to reproduce : 

* The user connect to user account.

* The user log out and kill up the application

*The user try to access again to exo application

Current behavior: 

The authentication page Microsoft  displayed

Expected behavior : 

The card screen displayed

Please have a look at the attached file for more details.