### PR TITLE
55247 : When downloading a file from the activity stream, the Exo app is closed automatically

### DIFF
--- a/app/src/main/java/org/exoplatform/fragment/PlatformWebViewFragment.java
+++ b/app/src/main/java/org/exoplatform/fragment/PlatformWebViewFragment.java
@@ -294,7 +294,10 @@ public class PlatformWebViewFragment extends Fragment {
           requestPermissions(new String[]{ WRITE_EXTERNAL_STORAGE },
                   WRITE_EXTERNAL_STORAGE_PERMISSION_REQUEST);
         } else {
-          downloadFile(url, userAgent, contentDisposition);
+          // Prevent blob urls form being handled
+          if (!url.startsWith("blob")) {
+            downloadFile(url, userAgent, contentDisposition);
+          }
         }
       }
     });


### PR DESCRIPTION
In this task we just fixed the crash related to download file from specific urls
Reason: the blob urls is not a HTTPURLResponse.
Fix : actually we prevent handled the blob urls in this task.