### PR TITLE
TASK-57263: Push notifications still received after logout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ fastlane/screenshots
 fastlane/test_output
 
 keystore.properties
+
+# android studio project files
+.idea/

--- a/app/src/main/java/org/exoplatform/activity/WebViewActivity.java
+++ b/app/src/main/java/org/exoplatform/activity/WebViewActivity.java
@@ -144,7 +144,7 @@ public class  WebViewActivity extends AppCompatActivity implements PlatformWebVi
 
   @Override
   public void onUserSignedOut() {
-    // fragments and activity will be cleaned-up automatically
+    mPlatformFragment.clearWebViewData();
   }
 
   @Override

--- a/app/src/main/java/org/exoplatform/fragment/PlatformWebViewFragment.java
+++ b/app/src/main/java/org/exoplatform/fragment/PlatformWebViewFragment.java
@@ -487,8 +487,8 @@ public class PlatformWebViewFragment extends Fragment {
       Log.d("shouldOverride", url);
       // For external and short links, broadcast logout event if done
       if (url.contains(LOGOUT_PATH)) {
-        clearWebviewData();
         mListener.onUserJustBeforeSignedOut();
+        mListener.onUserSignedOut();
       }
 
       if (url.contains(GOOGLE_LOGIN_PATH) || url.contains(FACEBOOK_LOGIN_PATH) || url.contains(LINKEDIN_LOGIN_PATH)) {
@@ -523,7 +523,6 @@ public class PlatformWebViewFragment extends Fragment {
       // Return to the previous activity if user has signed out
       String queryString = uri.getQuery();
       if (queryString != null && queryString.contains("portal:action=Logout")) {
-        clearWebviewData();
         mListener.onUserSignedOut();
       }
     }
@@ -545,9 +544,8 @@ public class PlatformWebViewFragment extends Fragment {
     }
   }
 
-  // Clear Webview cache and data before logging out.
-
-  private void clearWebviewData() {
+  // Clear Webview cache and data when logging out.
+  public void clearWebViewData() {
     mWebView.clearCache(true);
     mWebView.clearFormData();
     mWebView.clearHistory();


### PR DESCRIPTION
Prior to this change, clearWebViewData was clearing all app data before logout includes the user context information those are needed in rest filter verifications to allow to proceed the call of the rest endpoint to delete the user token.
This PR should make sure to delete user token before clearing the data.