### PR TITLE
Task-56650: Display correct error when server URL is invalid

### DIFF
--- a/app/src/main/java/org/exoplatform/tool/ServerUtils.java
+++ b/app/src/main/java/org/exoplatform/tool/ServerUtils.java
@@ -137,7 +137,7 @@ public class ServerUtils {
 
   public static void HandleThrowableException(ServerVerificationCallback callback,Throwable t){
     Log.e(LOG_TAG, "Unable to retrieve platform information", t);
-    if (t instanceof ConnectException || t instanceof SocketTimeoutException) {
+    if (t instanceof ConnectException) {
       callback.onConnectionError();
     }else{
       callback.onServerInvalid();


### PR DESCRIPTION
Steps to reproduce :

 Launch the exo application 
Click on "Enter server URL" button 
Enter a wrong eXo url adrees to connect and click on Validate URL button 
Actual behavior : 
a lost connection pop up is displayed ==> please have a look at attachment
Excepted behavior : 
Pop up display witch contains : 
text : Please enter a valid URL 
OK button 