### PR TITLE
Task-60655: Mobile_Android_Visioconference_Task ; Join a call on mobile

### DIFF
--- a/app/src/main/java/org/exoplatform/fragment/PlatformWebViewFragment.java
+++ b/app/src/main/java/org/exoplatform/fragment/PlatformWebViewFragment.java
@@ -48,6 +48,7 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.WindowManager;
+import android.webkit.ConsoleMessage;
 import android.webkit.CookieManager;
 import android.webkit.DownloadListener;
 import android.webkit.JsResult;
@@ -235,7 +236,6 @@ public class PlatformWebViewFragment extends Fragment {
                         Manifest.permission.CAMERA };
                 ActivityCompat.requestPermissions(Objects.requireNonNull(getActivity()),permissions,1010);
               }
-              switchToJitsiAppWith(url);
               return false;
             }
             @Override
@@ -250,6 +250,12 @@ public class PlatformWebViewFragment extends Fragment {
           //setDownloadListenerFor(newWebView,getContext());
           // Set the created window to be closed automatically when we have Jitsi call or google sign in (related to JS window.close()).
           newWebView.setWebChromeClient(new WebChromeClient() {
+            @Override
+            public boolean onConsoleMessage(ConsoleMessage consoleMessage) {
+              String url = consoleMessage.sourceId();
+              switchToJitsiAppWith(url);
+              return true;
+            }
             @Override
             public void onCloseWindow(WebView window) {
               super.onCloseWindow(window);
@@ -321,19 +327,19 @@ public class PlatformWebViewFragment extends Fragment {
     return layout;
   }
 
-  public boolean switchToJitsiAppWith(String url){
-    if (url.contains("/jitsiweb/") && url.contains("?jwt=")){
-      Uri uri = Uri.parse("org.jitsi.meet://" + url.replace("intent://",""));
+  public void switchToJitsiAppWith(String url){
+    if (url.contains("/jitsiweb/") && url.contains("?jwt=") && !url.contains("intent://")){
+      String fUrl = url.replaceFirst("^(http[s]?://)","");
+      Uri uri = Uri.parse("org.jitsi.meet://" + fUrl);
       Intent jitsiURL = new Intent(Intent.ACTION_VIEW, uri);
       jitsiURL.setPackage("org.jitsi.meet");
       try {
         startActivity(jitsiURL);
+        newWebView.getWebChromeClient().onCloseWindow(newWebView);
       } catch (ActivityNotFoundException e) {
-        Toast.makeText(getActivity(), "Jitsi meet is not on your mobile, install it before.", Toast.LENGTH_LONG).show();
+        Log.e("Jitsi App not found:", e.toString());
       }
-      return true;
     }
-    return false;
   }
 
   public static String getMimeType(String url) {

--- a/app/src/main/java/org/exoplatform/fragment/WebViewFragment.java
+++ b/app/src/main/java/org/exoplatform/fragment/WebViewFragment.java
@@ -22,12 +22,16 @@ package org.exoplatform.fragment;
 
 import android.Manifest;
 import android.annotation.SuppressLint;
+import android.content.ActivityNotFoundException;
 import android.content.Context;
+import android.content.Intent;
+import android.net.Uri;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.webkit.ConsoleMessage;
 import android.webkit.PermissionRequest;
 import android.webkit.WebChromeClient;
 import android.webkit.WebSettings;
@@ -110,6 +114,14 @@ public class WebViewFragment extends Fragment {
                              Manifest.permission.CAMERA };
     ActivityCompat.requestPermissions(getActivity(),permissions,1010);
     mWebView.setWebChromeClient(new WebChromeClient() {
+
+      @Override
+      public boolean onConsoleMessage(ConsoleMessage consoleMessage) {
+        String url = consoleMessage.sourceId();
+        switchToJitsiAppWith(url);
+        return true;
+      }
+
       @Override
       public void onReceivedTitle(WebView view, String title) {
         super.onReceivedTitle(view, title);
@@ -138,6 +150,21 @@ public class WebViewFragment extends Fragment {
 
     mWebView.loadUrl(mUrl);
     return layout;
+  }
+
+  public void switchToJitsiAppWith(String url){
+    if (url.contains("/jitsiweb/") && url.contains("?jwt=") && !url.contains("intent://")){
+      String fUrl = url.replaceFirst("^(http[s]?://)","");
+      Uri uri = Uri.parse("org.jitsi.meet://" + fUrl);
+      Intent jitsiURL = new Intent(Intent.ACTION_VIEW, uri);
+      jitsiURL.setPackage("org.jitsi.meet");
+      try {
+        startActivity(jitsiURL);
+        mListener.onCloseWebViewFragment();
+      } catch (ActivityNotFoundException e) {
+        Log.e("Jitsi App not found:", e.toString());
+      }
+    }
   }
 
   @Override


### PR DESCRIPTION
Current behavior:

When I try to join a call I have a jitsi page that proposes 3 options (join this meeting using the app, download the app, launch in web) to decide in which app the call should be opened.

Expected behavior: 

We should not have this page and the choice should be automatic according to our configuration: 

If I have on my phone the jitsi application already installed.

Then I'm redirected to the jitsi app and I have the loading page to join the appropriate call. 
When I close the call I'm on the jitsi app call history, I have to manually going back to eXo
If I do not have on my phone the jistsi application.

Then the call is launched on the browser. I stay on the eXo app, I don't remark that the call is launched in a browser as it's already implemented if I choose "launch in web". I have the loading page to join the call.
When I hang up the call, the call is closed and I'm going back to my previous opened page.