### PR TITLE
fix: device registration when user logins to the platform - EXO-64015

### DIFF
--- a/app/src/main/java/org/exoplatform/tool/cookies/UsernameCookieInterceptor.java
+++ b/app/src/main/java/org/exoplatform/tool/cookies/UsernameCookieInterceptor.java
@@ -34,37 +34,18 @@ import java.util.Map;
 
 class UsernameCookieInterceptor implements CookiesInterceptor {
 
-  private static final String USERNAME_COOKIE_KEY = "last_login_username";
   private static final String SESSION_COOKIE_KEY = "JSESSIONID";
   private static final String SESSIONSSO_COOKIE_KEY = "JSESSIONIDSSO";
   private static final String REMEMBERME_COOKIE_KEY = "rememberme";
 
   @Override
   public void intercept(Map<String, String> cookies, String url, Context context) {
-    if (cookies.containsKey(USERNAME_COOKIE_KEY)) {
-      PushTokenSynchronizerLocator.getInstance().setConnectedUserAndSync(cookies.get(USERNAME_COOKIE_KEY), calculateBaseUrl(url));
+    if (cookies.containsKey(SESSIONSSO_COOKIE_KEY)) {
       SharedPreferences shared = App.Preferences.get(context);
       SharedPreferences.Editor editor = shared.edit();
       String cookiesStr = SESSION_COOKIE_KEY+ "=" + cookies.get(SESSION_COOKIE_KEY) + ";" + REMEMBERME_COOKIE_KEY+ "=" + cookies.get(REMEMBERME_COOKIE_KEY) + ";" + SESSIONSSO_COOKIE_KEY+ "=" + cookies.get(SESSIONSSO_COOKIE_KEY);
-      editor.putString("connectedUsername",cookies.get(USERNAME_COOKIE_KEY));
       editor.putString("connectedCookies", cookiesStr);
       editor.apply();
-    }
-  }
-
-  @Nullable
-  private String calculateBaseUrl(String urlStr) {
-    try {
-      URL url = new URL(urlStr);
-      if (!TextUtils.isEmpty(url.getPath())) {
-        urlStr = urlStr.replaceFirst(url.getPath(), "");
-      }
-      if (!TextUtils.isEmpty(url.getQuery())) {
-        urlStr = urlStr.replaceFirst(url.getQuery(), "");
-      }
-      return urlStr;
-    } catch (Exception e) {
-      return null;
     }
   }
 }


### PR DESCRIPTION
Before eXo platform 6.5, Android app was relying on the **last_login_username** cookie to detect the current user.
This cookie was removed  and this caused a failure tpo register the phone for receiving Push notifications.
The fix  changed the implementation to read the JS variable **eXo.env.portal.userName** and use it to register the Android device on the platform to be able to receive push notifications