### PR TITLE
 fix: force reload internal eXo links inside the webview - EXO-70049 

### DIFF
--- a/app/src/main/java/org/exoplatform/fragment/PlatformWebViewFragment.java
+++ b/app/src/main/java/org/exoplatform/fragment/PlatformWebViewFragment.java
@@ -235,7 +235,7 @@ public class PlatformWebViewFragment extends Fragment {
                     newWebView.getWebChromeClient().onCloseWindow(view);
                   }
               }
-              if (!url.contains(mServer.getShortUrl()) || path.equals("/portal/dw/news/editor")) {
+              if (!url.contains(mServer.getShortUrl()) || (path != null && (path.startsWith("/portal/") || path.startsWith(mServer.getShortUrl() + "/portal")))) {
                 if (!url.contains(mServer.getShortUrl())) {
                   view.getContext().startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(url)));
                   newWebView.getWebChromeClient().onCloseWindow(view);
@@ -252,9 +252,8 @@ public class PlatformWebViewFragment extends Fragment {
                 for (String permission : permissions) {
                   if (ContextCompat.checkSelfPermission(getActivity(), permission) != PackageManager.PERMISSION_GRANTED) {
                     ActivityCompat.requestPermissions(getActivity(), permissions, 1010);
-                    break;
                   }
-                }
+                 }
               }
               return false;
             }
@@ -290,6 +289,7 @@ public class PlatformWebViewFragment extends Fragment {
             public void onPermissionRequest(PermissionRequest request) {
               request.grant(request.getResources());
             }
+
           });
         }
         return true;
@@ -474,8 +474,8 @@ public class PlatformWebViewFragment extends Fragment {
    * @return true if the webview did go back, false otherwise
    */
   public boolean goBack() {
-    if (mWebView != null && mWebView.canGoBack()) {
-      mWebView.goBack();
+    if (mWebView != null) {
+      mWebView.destroy();
       return true;
     }
     return false;

--- a/app/src/main/java/org/exoplatform/fragment/PlatformWebViewFragment.java
+++ b/app/src/main/java/org/exoplatform/fragment/PlatformWebViewFragment.java
@@ -474,8 +474,8 @@ public class PlatformWebViewFragment extends Fragment {
    * @return true if the webview did go back, false otherwise
    */
   public boolean goBack() {
-    if (mWebView != null) {
-      mWebView.destroy();
+    if (mWebView != null && mWebView.canGoBack()) {
+      mWebView.goBack();
       return true;
     }
     return false;


### PR DESCRIPTION
Before this fix, the application was refusing to open internal links when they are set to open in a new window (target="_blank"). There was an invalid cherck that does not cover all possible internal links.
After fixing this check, all Internal eXo links will be opened in the application,, external ones will eb opened by dedicated installed app (browser, specific app, etc ...)