### PR TITLE
fix: back/save button closes Notes editor - EXO-70231

### DIFF
--- a/app/src/main/java/org/exoplatform/fragment/PlatformWebViewFragment.java
+++ b/app/src/main/java/org/exoplatform/fragment/PlatformWebViewFragment.java
@@ -235,7 +235,7 @@ public class PlatformWebViewFragment extends Fragment {
                     newWebView.getWebChromeClient().onCloseWindow(view);
                   }
               }
-              if (!url.contains(mServer.getShortUrl()) || (path != null && (path.startsWith("/portal/") || path.startsWith(mServer.getShortUrl() + "/portal")))) {
+              if (!url.contains(mServer.getShortUrl()) || (path != null && (path.startsWith("/portal/") || url.startsWith(mServer.getUrl() + "/portal")))) {
                 if (!url.contains(mServer.getShortUrl())) {
                   view.getContext().startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(url)));
                   newWebView.getWebChromeClient().onCloseWindow(view);


### PR DESCRIPTION
When editing a Note, the page is not closeable and we had to close the app to get back to the previous page.
the fix makes sure to enable the back button and save button to return to the last page by opening the Notes/News editors in the current webview.