### PR TITLE
fix: Android 13 : enable send notification permission - EXO-70754

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,7 +2,10 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="org.exoplatform">
 
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+    <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />
@@ -17,7 +20,6 @@
 
     <application
         android:name=".App"
-        android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="eXo${appLabelEnvironmentSuffix}"
         android:theme="@style/MainTheme">

--- a/app/src/main/java/org/exoplatform/App.java
+++ b/app/src/main/java/org/exoplatform/App.java
@@ -24,16 +24,6 @@ import android.app.Application;
 import android.content.Context;
 import android.content.SharedPreferences;
 
-import com.crashlytics.android.Crashlytics;
-import com.google.android.gms.tasks.OnSuccessListener;
-import com.google.firebase.iid.FirebaseInstanceId;
-import com.google.firebase.iid.InstanceIdResult;
-
-import org.exoplatform.service.push.PushTokenStorage;
-import org.exoplatform.service.push.PushTokenSynchronizerLocator;
-
-import io.fabric.sdk.android.Fabric;
-
 /**
  * Exo Application instance and constants.
  * @author chautn on 10/26/15.
@@ -43,15 +33,6 @@ public class App extends Application {
   @Override
   public void onCreate() {
     super.onCreate();
-    Fabric.with(this, new Crashlytics());
-    FirebaseInstanceId.getInstance().getInstanceId().addOnSuccessListener(new OnSuccessListener<InstanceIdResult>() {
-      @Override
-      public void onSuccess(InstanceIdResult instanceIdResult) {
-        String newToken = instanceIdResult.getToken();
-        PushTokenStorage.getInstance().setPushToken(newToken, getApplicationContext());
-        PushTokenSynchronizerLocator.getInstance().setTokenAndSync(newToken);
-      }
-    });
   }
 
   public static final String TRIBE_URL      = "https://community.exoplatform.com";

--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,6 @@ task clean(type: Delete) {
 
 // This block encapsulate custom properties and make them available to all modules in the project.
 ext {
-    minSdkVersion = 28 // Android 9.0 Pie
-    compileSdkVersion = 31
+    minSdkVersion = 33 // Android 9.0 Pie
+    compileSdkVersion = 33
 }


### PR DESCRIPTION
Starting Android 13, we need to ask permission for sending notifications.
Thus the **POST_NOTIFICATION** permission was added to the manifest and it will be displayed when the app is started to ask the user for confirmation.
