### PR TITLE
fix: preview correctly images with special chars and fix download files from chat - EXO-70047

### DIFF
--- a/app/src/main/java/org/exoplatform/fragment/PlatformWebViewFragment.java
+++ b/app/src/main/java/org/exoplatform/fragment/PlatformWebViewFragment.java
@@ -254,10 +254,12 @@ public class PlatformWebViewFragment extends Fragment {
               String contentType = getMimeType(url);
               if (contentType != null && !contentType.contains("text/html")) {
                   refreshLayoutForContent(contentType);
-                  if (url.contains("/download/") || !contentType.startsWith("image/")){
+                  if (url.contains("/download/") || (url.contains("/portal/rest/jcr") && !contentType.startsWith("image/"))){
                     refreshLayoutForContent("text/html");
                     downloadFile(url,ua,contentType);
-                    newWebView.getWebChromeClient().onCloseWindow(view);
+                    if(newWebView.getWebChromeClient() != null) {
+                      newWebView.getWebChromeClient().onCloseWindow(view);
+                    }
                   }
               }
               if (!url.contains(mServer.getShortUrl()) || url.startsWith(mServer.getUrl() + "/portal")) {


### PR DESCRIPTION
Files having HTML special chars are not recognized by the Mimetype resolver because they have encoded chars.
the fix decodes their names to get the original name and extract the extension correctly.
Besides this fix re-enables downloading directly files from the Chat 